### PR TITLE
fix: marketplace.json owner.email 필드 추가 (#7)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "harness-marketplace",
   "owner": {
     "name": "revfactory",
-    "email": "",
+    "email": "robin.hwang@kakaocorp.com",
     "url": "https://github.com/revfactory"
   },
   "plugins": [


### PR DESCRIPTION
## Summary
- `.claude-plugin/marketplace.json`의 `owner.email` 필드가 빈 문자열이어서 Copilot CLI 등 다른 CLI에서 마켓플레이스 검증을 통과하지 못하는 문제를 해결합니다.
- 유효한 이메일(`robin.hwang@kakaocorp.com`)을 채워 다른 CLI에서도 설치할 수 있도록 합니다.

Closes #7

## Test plan
- [ ] Copilot CLI 등 외부 CLI에서 \`revfactory/harness\` 마켓플레이스 추가가 성공하는지 확인
- [ ] Claude Code 마켓플레이스에서 기존 동작이 유지되는지 확인