### PR TITLE
fix: copy buttons silently fail on insecure origins (clipboard fallback)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1346,12 +1346,37 @@ document.querySelectorAll('.pattern-card').forEach(card => {
 });
 
 // ── Copy prompt from use case ──
+// Clipboard with a fallback for insecure contexts (e.g. the page opened via
+// file://), where navigator.clipboard is undefined and writeText() would throw,
+// leaving the copy buttons silently dead.
+function copyToClipboard(text) {
+  if (navigator.clipboard && window.isSecureContext) {
+    return navigator.clipboard.writeText(text);
+  }
+  return new Promise((resolve, reject) => {
+    try {
+      const ta = document.createElement('textarea');
+      ta.value = text;
+      ta.setAttribute('readonly', '');
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      const ok = document.execCommand('copy');
+      document.body.removeChild(ta);
+      ok ? resolve() : reject(new Error('copy command was rejected'));
+    } catch (err) {
+      reject(err);
+    }
+  });
+}
+
 function copyPrompt(el) {
   const hint = el.querySelector('.uc-copy-hint');
   const text = el.textContent.replace(hint.textContent, '').trim();
   const copiedText = (i18n['common.copied'] && i18n['common.copied'][currentLang]) || 'Copied!';
   const clickText = (i18n['common.click_to_copy'] && i18n['common.click_to_copy'][currentLang]) || 'Click to copy';
-  navigator.clipboard.writeText(text).then(() => {
+  copyToClipboard(text).then(() => {
     el.classList.add('copied');
     hint.textContent = copiedText;
     setTimeout(() => { el.classList.remove('copied'); hint.textContent = clickText; }, 2000);
@@ -1372,7 +1397,7 @@ function copyCode(block) {
   const cmd = block.querySelector('.cmd').textContent;
   const copiedText = (i18n['common.copied'] && i18n['common.copied'][currentLang]) || 'Copied!';
   const copyText = (i18n['common.copy'] && i18n['common.copy'][currentLang]) || 'Copy';
-  navigator.clipboard.writeText(cmd).then(() => {
+  copyToClipboard(cmd).then(() => {
     const btn = block.querySelector('.copy-btn');
     btn.textContent = copiedText;
     btn.classList.add('copied');


### PR DESCRIPTION
## What

The "copy" buttons on the landing page (`copyPrompt` / `copyCode`) silently do nothing when `index.html` is opened in an insecure context — most commonly via `file://` (e.g. cloning the repo and opening the page locally).

## Why

```js
navigator.clipboard.writeText(text).then(() => { ... });
```

`navigator.clipboard` is only defined in secure contexts (`https:` or `localhost`). Over `file://` (or plain `http://`) it's `undefined`, so `navigator.clipboard.writeText(...)` throws `TypeError` synchronously: the click handler aborts, no text is copied, and the "Copied!" feedback never shows. There's also no `.catch`, so the rejection path is unhandled.

This works on the production GitHub Pages site (https), but breaks for anyone previewing the page locally.

## Fix

Route both handlers through a `copyToClipboard()` helper that uses the async Clipboard API in secure contexts and falls back to a hidden-`<textarea>` + `document.execCommand('copy')` otherwise.

## Verification

Static page (no test harness). `node --check` on the page's script passes; the only remaining `navigator.clipboard.writeText` is inside the helper, guarded by `navigator.clipboard && window.isSecureContext`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
