### PR TITLE
fix: validate the stored language before using it (detectLang)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1163,7 +1163,7 @@ function detectLang() {
   const hash = location.hash.replace('#', '').toLowerCase();
   if (['en', 'ko', 'ja'].includes(hash)) return hash;
   const stored = localStorage.getItem('harness-lang');
-  if (stored) return stored;
+  if (stored && ['en', 'ko', 'ja'].includes(stored)) return stored;
   const nav = (navigator.language || '').toLowerCase();
   if (nav.startsWith('ko')) return 'ko';
   if (nav.startsWith('ja')) return 'ja';


### PR DESCRIPTION
## What

`detectLang()` validates the URL-hash language but trusts the `localStorage` value unchecked, so a stale/invalid stored value leaves the page silently stuck in English.

## Why

```js
const hash = location.hash.replace('#', '').toLowerCase();
if (['en', 'ko', 'ja'].includes(hash)) return hash;   // validated
const stored = localStorage.getItem('harness-lang');
if (stored) return stored;                              // NOT validated
```

If `harness-lang` ever holds a value outside `en|ko|ja` (a future rename, a stale key, etc.), `detectLang` returns it, and `setLang` then fails every `i18n[key][lang]` lookup — leaving all text in English with no active language button — instead of falling through to the `navigator.language` / `'en'` default.

## Fix

Validate the stored value against the same allowed set as the hash path:

```js
if (stored && ['en', 'ko', 'ja'].includes(stored)) return stored;
```

Small consistency/robustness fix; makes both code paths agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
