### PR TITLE
fix(docs): correct plugin install command to harness@harness-marketplace

### DIFF
--- a/README_JA.md
+++ b/README_JA.md
@@ -89,7 +89,7 @@ Phase 6: 検証とテスト
 
 #### プラグインのインストール
 ```shell
-/plugin install harness-marketplace
+/plugin install harness@harness-marketplace
 ```
 
 ### グローバルスキルとして直接インストール

--- a/README_KO.md
+++ b/README_KO.md
@@ -89,7 +89,7 @@ Phase 6: 검증 및 테스트
 
 #### 플러그인 설치
 ```shell
-/plugin install harness-marketplace
+/plugin install harness@harness-marketplace
 ```
 
 ### 글로벌 스킬로 직접 설치

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -28,7 +28,7 @@ claude plugin marketplace add revfactory/harness
 ## Step 2 — Install the plugin and enable the Experimental flag (40 seconds)
 
 ```bash
-claude plugin install harness@harness
+claude plugin install harness@harness-marketplace
 export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
 ```
 
@@ -76,7 +76,7 @@ ls -la .claude/skills/
 
 **Failure FAQ #3 — "Nothing was generated" / directories are empty**
 **Cause:** The plugin is not actually installed or is not active in the current project.
-**Fix:** Run `claude plugin list`. If `harness@harness` is absent, repeat Step 2. If present but inactive, run `claude plugin enable harness@harness`, then repeat Step 3.
+**Fix:** Run `claude plugin list`. If `harness@harness-marketplace` is absent, repeat Step 2. If present but inactive, run `claude plugin enable harness@harness-marketplace`, then repeat Step 3.
 
 ---
 


### PR DESCRIPTION
## Summary
- The Korean/Japanese READMEs and the Quickstart guide use plugin-install commands that don't match the names declared in `.claude-plugin/marketplace.json` (marketplace name `harness-marketplace`, plugin name `harness`). Copy-pasting them fails to install the plugin.
- This aligns all three with the already-correct English `README.md`, which uses `harness@harness-marketplace`.

## Changes
- `README_KO.md`: `/plugin install harness-marketplace` → `/plugin install harness@harness-marketplace`
- `README_JA.md`: same fix
- `docs/quickstart.md`: `harness@harness` → `harness@harness-marketplace` in the Step 2 install command and the two `plugin list` / `plugin enable` references in Failure FAQ #3

## Test Plan
- [ ] `.claude-plugin/marketplace.json` declares marketplace `harness-marketplace` + plugin `harness`, so `harness@harness-marketplace` is the correct reference
- [ ] `grep -rn "harness@harness" README*.md docs/` — every occurrence is now followed by `-marketplace`
- [ ] `claude plugin marketplace add revfactory/harness` then `claude plugin install harness@harness-marketplace` succeeds end-to-end

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
